### PR TITLE
Fix progress component to avoid build errors

### DIFF
--- a/project/components/ui/progress.tsx
+++ b/project/components/ui/progress.tsx
@@ -1,28 +1,36 @@
 'use client';
 
 import * as React from 'react';
-import * as ProgressPrimitive from '@radix-ui/react-progress';
 
 import { cn } from '@/lib/utils';
 
-const Progress = React.forwardRef<
-  React.ElementRef<typeof ProgressPrimitive.Root>,
-  React.ComponentPropsWithoutRef<typeof ProgressPrimitive.Root>
->(({ className, value, ...props }, ref) => (
-  <ProgressPrimitive.Root
-    ref={ref}
-    className={cn(
-      'relative h-4 w-full overflow-hidden rounded-full bg-secondary',
-      className
-    )}
-    {...props}
-  >
-    <ProgressPrimitive.Indicator
-      className="h-full w-full flex-1 bg-primary transition-all"
-      style={{ transform: `translateX(-${100 - (value || 0)}%)` }}
-    />
-  </ProgressPrimitive.Root>
-));
-Progress.displayName = ProgressPrimitive.Root.displayName;
+export interface ProgressProps extends React.ComponentPropsWithoutRef<'div'> {
+  value?: number
+  max?: number
+}
+
+const Progress = React.forwardRef<HTMLDivElement, ProgressProps>(
+  ({ className, value = 0, max = 100, ...props }, ref) => {
+    const clamped = Math.min(Math.max(value, 0), max)
+    const percentage = (clamped / max) * 100
+
+    return (
+      <div
+        ref={ref}
+        className={cn(
+          'relative h-4 w-full overflow-hidden rounded-full bg-secondary',
+          className
+        )}
+        {...props}
+      >
+        <div
+          className="h-full bg-primary transition-all"
+          style={{ width: `${percentage}%` }}
+        />
+      </div>
+    )
+  }
+)
+Progress.displayName = 'Progress'
 
 export { Progress };

--- a/project/package.json
+++ b/project/package.json
@@ -13,7 +13,6 @@
     "@radix-ui/react-dialog": "^1.1.1",
     "@radix-ui/react-label": "^2.1.0",
     "@radix-ui/react-popover": "^1.1.1",
-    "@radix-ui/react-progress": "^1.1.0",
     "@radix-ui/react-select": "^2.1.1",
     "@radix-ui/react-slot": "^1.1.0",
     "@radix-ui/react-switch": "^1.1.0",


### PR DESCRIPTION
## Summary
- remove `@radix-ui/react-progress` usage and implement a simple custom progress bar
- drop `@radix-ui/react-progress` from dependencies

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a785a3d9c8320bf82437d9ebe1f05