### PR TITLE
Add policy details dialog component

### DIFF
--- a/project/app/(admin)/admin/policies/page.tsx
+++ b/project/app/(admin)/admin/policies/page.tsx
@@ -10,6 +10,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from '@/components/ui/dialog';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Pagination } from '@/components/shared/Pagination';
+import PolicyDetailsDialog from '@/components/shared/PolicyDetailsDialog';
 import { 
   Plus, 
   Search, 
@@ -31,6 +32,7 @@ export default function ManagePolicies() {
   const [filterCategory, setFilterCategory] = useState('all');
   const [isCreateDialogOpen, setIsCreateDialogOpen] = useState(false);
   const [selectedPolicy, setSelectedPolicy] = useState<any>(null);
+  const [isDetailsDialogOpen, setIsDetailsDialogOpen] = useState(false);
   const [currentPage, setCurrentPage] = useState(1);
   const [itemsPerPage, setItemsPerPage] = useState(15);
 
@@ -820,7 +822,14 @@ export default function ManagePolicies() {
                   </div>
 
                   <div className="flex gap-2 pt-4 border-t border-slate-100 dark:border-slate-700">
-                    <Button variant="outline" className="flex-1 floating-button">
+                    <Button
+                      variant="outline"
+                      className="flex-1 floating-button"
+                      onClick={() => {
+                        setSelectedPolicy(policy);
+                        setIsDetailsDialogOpen(true);
+                      }}
+                    >
                       <Eye className="w-4 h-4 mr-2" />
                       View Details
                     </Button>
@@ -857,6 +866,16 @@ export default function ManagePolicies() {
           </div>
         )}
       </div>
+      {selectedPolicy && (
+        <PolicyDetailsDialog
+          policy={selectedPolicy}
+          open={isDetailsDialogOpen}
+          onClose={() => {
+            setIsDetailsDialogOpen(false);
+            setSelectedPolicy(null);
+          }}
+        />
+      )}
     </div>
   );
 }

--- a/project/components/shared/PolicyDetailsDialog.tsx
+++ b/project/components/shared/PolicyDetailsDialog.tsx
@@ -1,0 +1,203 @@
+import React from 'react';
+import { Dialog, DialogTitle, DialogContent, IconButton, Typography, Chip, Divider, Grid, Box } from '@mui/material';
+import CloseIcon from '@mui/icons-material/Close';
+import { styled } from '@mui/material/styles';
+import { format } from 'date-fns';
+
+export interface Policy {
+  id: string | number;
+  name: string;
+  category?: string;
+  provider?: string;
+  coverage?: number;
+  premium?: number;
+  sales?: number;
+  revenue?: number;
+  created?: Date | string;
+  lastUpdated?: Date | string;
+  description?: string;
+  features?: string[];
+  terms?: string;
+  status?: 'active' | 'inactive';
+}
+
+export interface PolicyDetailsDialogProps {
+  policy: Policy;
+  open: boolean;
+  onClose: () => void;
+}
+
+const Header = styled(Box)(({ theme }) => ({
+  display: 'flex',
+  justifyContent: 'space-between',
+  alignItems: 'center',
+  padding: theme.spacing(2, 3),
+  borderBottom: `1px solid ${theme.palette.divider}`,
+}));
+
+const Section = styled(Box)(({ theme }) => ({
+  marginBottom: theme.spacing(3),
+}));
+
+const SectionTitle = styled(Typography)(({ theme }) => ({
+  marginBottom: theme.spacing(1),
+  fontWeight: 600,
+}));
+
+const currency = new Intl.NumberFormat('en-US', {
+  style: 'currency',
+  currency: 'USD',
+});
+
+function formatDate(value?: Date | string) {
+  if (!value) return '';
+  const date = typeof value === 'string' ? new Date(value) : value;
+  return format(date, 'PPP');
+}
+
+export function PolicyDetailsDialog({ policy, open, onClose }: PolicyDetailsDialogProps) {
+  return (
+    <Dialog open={open} onClose={onClose} fullWidth maxWidth="md">
+      <Header>
+        <Typography variant="h6" component="div" noWrap>
+          {policy.name}
+        </Typography>
+        <Chip
+          label={policy.status === 'active' ? 'Active' : 'Inactive'}
+          color={policy.status === 'active' ? 'success' : 'default'}
+          size="small"
+          sx={{ marginLeft: 1 }}
+        />
+        <IconButton onClick={onClose} size="small" sx={{ marginLeft: 'auto' }}>
+          <CloseIcon />
+        </IconButton>
+      </Header>
+      <DialogContent dividers sx={{ padding: 3 }}>
+        <Section>
+          <SectionTitle variant="subtitle1">Basic Information</SectionTitle>
+          <Grid container spacing={2}>
+            <Grid item xs={12} md={6}>
+              <Typography variant="body2" color="text.secondary">
+                Policy ID
+              </Typography>
+              <Typography variant="body1" noWrap>
+                {policy.id}
+              </Typography>
+            </Grid>
+            <Grid item xs={12} md={6}>
+              <Typography variant="body2" color="text.secondary">
+                Category
+              </Typography>
+              <Typography variant="body1" noWrap>
+                {policy.category || '-'}
+              </Typography>
+            </Grid>
+            <Grid item xs={12} md={6}>
+              <Typography variant="body2" color="text.secondary">
+                Provider
+              </Typography>
+              <Typography variant="body1" noWrap>
+                {policy.provider || '-'}
+              </Typography>
+            </Grid>
+          </Grid>
+        </Section>
+
+        <Divider />
+
+        <Section>
+          <SectionTitle variant="subtitle1">Financial Details</SectionTitle>
+          <Grid container spacing={2}>
+            <Grid item xs={12} md={6}>
+              <Typography variant="body2" color="text.secondary">
+                Coverage
+              </Typography>
+              <Typography variant="body1" noWrap>
+                {policy.coverage != null ? currency.format(policy.coverage) : '-'}
+              </Typography>
+            </Grid>
+            <Grid item xs={12} md={6}>
+              <Typography variant="body2" color="text.secondary">
+                Premium
+              </Typography>
+              <Typography variant="body1" noWrap>
+                {policy.premium != null ? currency.format(policy.premium) : '-'}
+              </Typography>
+            </Grid>
+            <Grid item xs={12} md={6}>
+              <Typography variant="body2" color="text.secondary">
+                Sales
+              </Typography>
+              <Typography variant="body1" noWrap>
+                {policy.sales != null ? currency.format(policy.sales) : '-'}
+              </Typography>
+            </Grid>
+            <Grid item xs={12} md={6}>
+              <Typography variant="body2" color="text.secondary">
+                Revenue
+              </Typography>
+              <Typography variant="body1" noWrap>
+                {policy.revenue != null ? currency.format(policy.revenue) : '-'}
+              </Typography>
+            </Grid>
+          </Grid>
+        </Section>
+
+        <Divider />
+
+        <Section>
+          <SectionTitle variant="subtitle1">Dates</SectionTitle>
+          <Grid container spacing={2}>
+            <Grid item xs={12} md={6}>
+              <Typography variant="body2" color="text.secondary">
+                Created
+              </Typography>
+              <Typography variant="body1" noWrap>
+                {formatDate(policy.created)}
+              </Typography>
+            </Grid>
+            <Grid item xs={12} md={6}>
+              <Typography variant="body2" color="text.secondary">
+                Last Updated
+              </Typography>
+              <Typography variant="body1" noWrap>
+                {formatDate(policy.lastUpdated)}
+              </Typography>
+            </Grid>
+          </Grid>
+        </Section>
+
+        {policy.description && (
+          <Section>
+            <SectionTitle variant="subtitle1">Description</SectionTitle>
+            <Typography variant="body2" sx={{ whiteSpace: 'pre-line' }}>
+              {policy.description}
+            </Typography>
+          </Section>
+        )}
+
+        {policy.features && policy.features.length > 0 && (
+          <Section>
+            <SectionTitle variant="subtitle1">Features</SectionTitle>
+            <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
+              {policy.features.map((feature, idx) => (
+                <Chip key={idx} label={feature} size="small" />
+              ))}
+            </Box>
+          </Section>
+        )}
+
+        {policy.terms && (
+          <Section>
+            <SectionTitle variant="subtitle1">Terms</SectionTitle>
+            <Typography variant="body2" sx={{ whiteSpace: 'pre-line' }}>
+              {policy.terms}
+            </Typography>
+          </Section>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+export default PolicyDetailsDialog;

--- a/project/package.json
+++ b/project/package.json
@@ -31,7 +31,11 @@
     "react-dom": "18.2.0",
     "tailwind-merge": "^2.5.2",
     "tailwindcss": "3.3.3",
-    "typescript": "5.2.2"
+    "typescript": "5.2.2",
+    "@mui/material": "^5.15.15",
+    "@mui/icons-material": "^5.15.15",
+    "@emotion/react": "^11.11.1",
+    "@emotion/styled": "^11.11.0"
   },
   "devDependencies": {
     "autoprefixer": "10.4.15",


### PR DESCRIPTION
## Summary
- add Material-UI dependencies
- integrate `PolicyDetailsDialog` into admin policies page

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ce3292adc8320a23e19797d62a9b2