### PR TITLE
Add seasonal offer edit dialog

### DIFF
--- a/project/app/(admin)/admin/offers/page.tsx
+++ b/project/app/(admin)/admin/offers/page.tsx
@@ -11,6 +11,7 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from 
 import { Calendar } from '@/components/ui/calendar';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { Pagination } from '@/components/shared/Pagination';
+import EditOfferDialog from '@/components/shared/EditOfferDialog';
 import { 
   Gift, 
   Plus, 
@@ -33,6 +34,7 @@ const ITEMS_PER_PAGE = 8;
 export default function SeasonalOffers() {
   const [isCreateDialogOpen, setIsCreateDialogOpen] = useState(false);
   const [selectedOffer, setSelectedOffer] = useState<any>(null);
+  const [isEditDialogOpen, setIsEditDialogOpen] = useState(false);
   const [startDate, setStartDate] = useState<Date>();
   const [endDate, setEndDate] = useState<Date>();
   const [currentPage, setCurrentPage] = useState(1);
@@ -758,7 +760,14 @@ export default function SeasonalOffers() {
                 </div>
 
                 <div className="flex gap-2 pt-4 border-t border-slate-100 dark:border-slate-700">
-                  <Button variant="outline" className="flex-1 floating-button">
+                  <Button
+                    variant="outline"
+                    className="flex-1 floating-button"
+                    onClick={() => {
+                      setSelectedOffer(offer);
+                      setIsEditDialogOpen(true);
+                    }}
+                  >
                     <Edit className="w-4 h-4 mr-2" />
                     Edit
                   </Button>
@@ -796,6 +805,21 @@ export default function SeasonalOffers() {
           </div>
         )}
       </div>
+      {selectedOffer && (
+        <EditOfferDialog
+          offer={selectedOffer}
+          open={isEditDialogOpen}
+          onClose={() => {
+            setIsEditDialogOpen(false);
+            setSelectedOffer(null);
+          }}
+          onSave={(o) => {
+            console.log('Saving offer:', o);
+            setIsEditDialogOpen(false);
+            setSelectedOffer(null);
+          }}
+        />
+      )}
     </div>
   );
 }

--- a/project/components/shared/EditOfferDialog.tsx
+++ b/project/components/shared/EditOfferDialog.tsx
@@ -1,0 +1,219 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { Calendar } from '@/components/ui/calendar';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import { Calendar as CalendarIcon, Save } from 'lucide-react';
+import { format } from 'date-fns';
+
+export interface Offer {
+  id: string | number;
+  title: string;
+  description?: string;
+  discountType: 'percentage' | 'fixed' | string;
+  discountValue?: string | number;
+  targetAudience?: string;
+  policyCategories?: string[];
+  minPurchase?: string;
+  maxDiscount?: string;
+  startDate?: Date | string | null;
+  endDate?: Date | string | null;
+  status?: string;
+}
+
+export interface EditOfferDialogProps {
+  offer: Offer;
+  open: boolean;
+  onClose: () => void;
+  onSave?: (offer: Offer) => void;
+}
+
+export default function EditOfferDialog({ offer, open, onClose, onSave }: EditOfferDialogProps) {
+  const [formData, setFormData] = useState<Offer>({ ...offer });
+  const [startDate, setStartDate] = useState<Date | undefined>(undefined);
+  const [endDate, setEndDate] = useState<Date | undefined>(undefined);
+
+  useEffect(() => {
+    if (open) {
+      setFormData({ ...offer });
+      setStartDate(offer.startDate ? new Date(offer.startDate as any) : undefined);
+      setEndDate(offer.endDate ? new Date(offer.endDate as any) : undefined);
+    }
+  }, [open, offer]);
+
+  const handleSave = () => {
+    onSave?.({
+      ...formData,
+      startDate,
+      endDate,
+    });
+    onClose();
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={(o) => !o && onClose()}>
+      <DialogContent onOpenAutoFocus={(e) => e.preventDefault()} className="max-w-4xl max-h-[80vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>Edit Offer</DialogTitle>
+        </DialogHeader>
+        <div className="space-y-6">
+          <div className="grid md:grid-cols-2 gap-6">
+            <div>
+              <label className="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-2">
+                Offer Title
+              </label>
+              <Input
+                value={formData.title}
+                onChange={(e) => setFormData({ ...formData, title: e.target.value })}
+                className="form-input"
+                placeholder="Enter offer title"
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-2">
+                Target Audience
+              </label>
+              <Select
+                value={formData.targetAudience}
+                onValueChange={(value) => setFormData({ ...formData, targetAudience: value })}
+              >
+                <SelectTrigger className="form-input">
+                  <SelectValue placeholder="Select target audience" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="all">All Customers</SelectItem>
+                  <SelectItem value="new-customers">New Customers</SelectItem>
+                  <SelectItem value="existing-customers">Existing Customers</SelectItem>
+                  <SelectItem value="premium-customers">Premium Customers</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-2">
+              Description
+            </label>
+            <Textarea
+              value={formData.description || ''}
+              onChange={(e) => setFormData({ ...formData, description: e.target.value })}
+              className="form-input min-h-[100px]"
+              placeholder="Describe the offer and its benefits"
+            />
+          </div>
+
+          <div className="grid md:grid-cols-3 gap-6">
+            <div>
+              <label className="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-2">
+                Discount Type
+              </label>
+              <Select
+                value={formData.discountType}
+                onValueChange={(value) => setFormData({ ...formData, discountType: value })}
+              >
+                <SelectTrigger className="form-input">
+                  <SelectValue placeholder="Select discount type" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="percentage">Percentage</SelectItem>
+                  <SelectItem value="fixed">Fixed Amount</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-2">
+                Discount Value
+              </label>
+              <Input
+                value={formData.discountValue as any}
+                onChange={(e) => setFormData({ ...formData, discountValue: e.target.value })}
+                placeholder={formData.discountType === 'percentage' ? 'e.g., 25' : 'e.g., 0.1 ETH'}
+                className="form-input"
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-2">
+                Max Discount
+              </label>
+              <Input
+                value={formData.maxDiscount as any}
+                onChange={(e) => setFormData({ ...formData, maxDiscount: e.target.value })}
+                placeholder="e.g., 2 ETH"
+                className="form-input"
+              />
+            </div>
+          </div>
+
+          <div className="grid md:grid-cols-2 gap-6">
+            <div>
+              <label className="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-2">
+                Start Date
+              </label>
+              <Popover>
+                <PopoverTrigger asChild>
+                  <Button variant="outline" className="w-full justify-start text-left font-normal form-input">
+                    <CalendarIcon className="mr-2 h-4 w-4" />
+                    {startDate ? format(startDate, 'PPP') : 'Pick a date'}
+                  </Button>
+                </PopoverTrigger>
+                <PopoverContent className="w-auto p-0">
+                  <Calendar mode="single" selected={startDate} onSelect={setStartDate} initialFocus />
+                </PopoverContent>
+              </Popover>
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-2">
+                End Date
+              </label>
+              <Popover>
+                <PopoverTrigger asChild>
+                  <Button variant="outline" className="w-full justify-start text-left font-normal form-input">
+                    <CalendarIcon className="mr-2 h-4 w-4" />
+                    {endDate ? format(endDate, 'PPP') : 'Pick a date'}
+                  </Button>
+                </PopoverTrigger>
+                <PopoverContent className="w-auto p-0">
+                  <Calendar mode="single" selected={endDate} onSelect={setEndDate} initialFocus />
+                </PopoverContent>
+              </Popover>
+            </div>
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-2">
+              Minimum Purchase Amount
+            </label>
+            <Input
+              value={formData.minPurchase as any}
+              onChange={(e) => setFormData({ ...formData, minPurchase: e.target.value })}
+              placeholder="e.g., 0.5 ETH"
+              className="form-input"
+            />
+          </div>
+
+          <div className="flex gap-4 pt-4 border-t border-slate-200 dark:border-slate-700">
+            <Button variant="outline" onClick={onClose} className="flex-1">
+              Cancel
+            </Button>
+            <Button onClick={handleSave} className="flex-1 gradient-accent text-white floating-button">
+              <Save className="w-4 h-4 mr-2" />
+              Save Changes
+            </Button>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+


### PR DESCRIPTION
## Summary
- create `EditOfferDialog` component for editing seasonal offers
- integrate edit dialog into admin offers page

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d559e12048320a0315f456ad7ed11