### PR TITLE
Add policy details dialog and token purchase flow

### DIFF
--- a/project/app/(policyholder)/policyholder/browse/page.tsx
+++ b/project/app/(policyholder)/policyholder/browse/page.tsx
@@ -9,6 +9,9 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { Pagination } from '@/components/shared/Pagination';
 import { Heart, Plane, Sprout, Shield, Search, Filter, Star } from 'lucide-react';
 import { policyCategories, policies } from '@/public/data/policyholder/browseData';
+import PolicyDetailsDialog, { Policy } from '@/components/shared/PolicyDetailsDialog';
+import Link from 'next/link';
+import { logEvent } from '@/lib/analytics';
 
 const ITEMS_PER_PAGE = 6;
 
@@ -17,6 +20,8 @@ export default function BrowsePolicies() {
   const [selectedCategory, setSelectedCategory] = useState('all');
   const [sortBy, setSortBy] = useState('popular');
   const [currentPage, setCurrentPage] = useState(1);
+  const [showDetails, setShowDetails] = useState(false);
+  const [selectedPolicy, setSelectedPolicy] = useState<Policy | null>(null);
   const filteredPolicies = useMemo(() => {
     let filtered = policies.filter(policy => {
       const matchesSearch = policy.name.toLowerCase().includes(searchTerm.toLowerCase()) ||
@@ -54,6 +59,17 @@ export default function BrowsePolicies() {
   const handleFilterChange = (filterFn: () => void) => {
     filterFn();
     setCurrentPage(1);
+  };
+
+  const openDetails = (policy: Policy) => {
+    setSelectedPolicy(policy);
+    setShowDetails(true);
+    logEvent('open_policy_details', policy.id);
+  };
+
+  const closeDetails = () => {
+    setShowDetails(false);
+    if (selectedPolicy) logEvent('close_policy_details', selectedPolicy.id);
   };
 
   return (
@@ -207,12 +223,21 @@ export default function BrowsePolicies() {
                   </div>
 
                   <div className="flex gap-2">
-                    <Button variant="outline" className="flex-1 floating-button">
+                    <Button
+                      variant="outline"
+                      className="flex-1 floating-button"
+                      onClick={() => openDetails(policy)}
+                    >
                       Details
                     </Button>
-                    <Button className="flex-1 gradient-accent text-white floating-button">
-                      Buy with Token
-                    </Button>
+                    <Link href="/policyholder/buy-with-token" className="flex-1">
+                      <Button
+                        onClick={() => logEvent('start_purchase', policy.id)}
+                        className="w-full gradient-accent text-white floating-button"
+                      >
+                        Buy with Token
+                      </Button>
+                    </Link>
                   </div>
                 </CardContent>
               </Card>
@@ -237,6 +262,10 @@ export default function BrowsePolicies() {
             <h3 className="text-xl font-semibold text-slate-600 dark:text-slate-400 mb-2">No policies found</h3>
             <p className="text-slate-500 dark:text-slate-500">Try adjusting your search criteria</p>
           </div>
+        )}
+
+        {selectedPolicy && (
+          <PolicyDetailsDialog policy={selectedPolicy} open={showDetails} onClose={closeDetails} />
         )}
       </div>
     </div>

--- a/project/app/(policyholder)/policyholder/buy-with-token/page.tsx
+++ b/project/app/(policyholder)/policyholder/buy-with-token/page.tsx
@@ -1,0 +1,115 @@
+'use client';
+
+import { useState } from 'react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { CheckCircle, XCircle } from 'lucide-react';
+import { walletBalance } from '@/public/data/policyholder/walletData';
+import { logEvent } from '@/lib/analytics';
+
+export default function BuyWithToken() {
+  const policyCost = 0.8; // ETH
+  const [step, setStep] = useState(1);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [txHash, setTxHash] = useState<string | null>(null);
+
+  const handleApprove = async () => {
+    logEvent('approve_token_start');
+    setLoading(true);
+    setError(null);
+    setTimeout(() => {
+      if (parseFloat(walletBalance.eth) < policyCost) {
+        setError('Insufficient token balance');
+        logEvent('approve_token_failed', 'balance');
+      } else {
+        setStep(2);
+        logEvent('approve_token_success');
+      }
+      setLoading(false);
+    }, 1000);
+  };
+
+  const handlePurchase = async () => {
+    logEvent('purchase_start');
+    setLoading(true);
+    setError(null);
+    setTimeout(() => {
+      const success = Math.random() > 0.2;
+      if (success) {
+        setTxHash('0xabc123');
+        setStep(3);
+        logEvent('purchase_success');
+      } else {
+        setError('Transaction failed due to network issue');
+        logEvent('purchase_failed');
+      }
+      setLoading(false);
+    }, 1500);
+  };
+
+  const renderStep = () => {
+    switch (step) {
+      case 1:
+        return (
+          <div className="space-y-4">
+            <p className="text-slate-700 dark:text-slate-300">Balance: {walletBalance.eth} ETH</p>
+            <p className="text-slate-700 dark:text-slate-300">Policy cost: {policyCost} ETH</p>
+            {error && (
+              <Alert variant="destructive">
+                <AlertTitle>Error</AlertTitle>
+                <AlertDescription>{error}</AlertDescription>
+              </Alert>
+            )}
+            <Button onClick={handleApprove} disabled={loading} className="gradient-accent text-white w-full">
+              {loading ? 'Approving...' : 'Approve Tokens'}
+            </Button>
+          </div>
+        );
+      case 2:
+        return (
+          <div className="space-y-4">
+            <p className="text-slate-700 dark:text-slate-300">Tokens approved.</p>
+            {error && (
+              <Alert variant="destructive">
+                <AlertTitle>Error</AlertTitle>
+                <AlertDescription>{error}</AlertDescription>
+              </Alert>
+            )}
+            <Button onClick={handlePurchase} disabled={loading} className="gradient-accent text-white w-full">
+              {loading ? 'Purchasing...' : 'Confirm Purchase'}
+            </Button>
+          </div>
+        );
+      case 3:
+        return txHash ? (
+          <div className="text-center space-y-2">
+            <CheckCircle className="w-12 h-12 text-emerald-600 mx-auto" />
+            <p className="font-semibold text-slate-700 dark:text-slate-300">Purchase successful!</p>
+            <p className="text-sm text-slate-600 dark:text-slate-400">Tx Hash: {txHash}</p>
+          </div>
+        ) : (
+          <div className="text-center space-y-2">
+            <XCircle className="w-12 h-12 text-red-600 mx-auto" />
+            <p className="font-semibold text-red-600">Transaction failed</p>
+          </div>
+        );
+      default:
+        return null;
+    }
+  };
+
+  return (
+    <div className="section-spacing">
+      <div className="max-w-md mx-auto">
+        <Card className="glass-card rounded-2xl">
+          <CardHeader>
+            <CardTitle className="text-xl">Buy With Token</CardTitle>
+          </CardHeader>
+          <CardContent>{renderStep()}</CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/project/components/shared/PolicyDetailsDialog.tsx
+++ b/project/components/shared/PolicyDetailsDialog.tsx
@@ -1,7 +1,9 @@
 'use client';
 
-import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from '@/components/ui/dialog';
 import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Star, Download } from 'lucide-react';
 import { format } from 'date-fns';
 import { cn } from '@/lib/utils';
 
@@ -19,6 +21,9 @@ export interface Policy {
   description?: string;
   features?: string[];
   terms?: string;
+  documents?: { name: string; url: string }[];
+  reviews?: { user: string; rating: number; comment: string }[];
+  rating?: number;
   status?: 'active' | 'inactive' | string;
 }
 
@@ -86,6 +91,22 @@ export default function PolicyDetailsDialog({ policy, open, onClose }: PolicyDet
                   {policy.provider || '-'}
                 </p>
               </div>
+              {policy.rating !== undefined && (
+                <div className="space-y-1">
+                  <p className="text-sm text-slate-600 dark:text-slate-400">Rating</p>
+                  <div className="flex items-center">
+                    {Array.from({ length: 5 }).map((_, i) => (
+                      <Star
+                        key={i}
+                        className={`w-4 h-4 ${i < Math.round(policy.rating!) ? 'fill-yellow-500 text-yellow-500' : 'text-slate-400'}`}
+                      />
+                    ))}
+                    <span className="ml-2 text-sm text-slate-700 dark:text-slate-300">
+                      {policy.rating?.toFixed(1)}
+                    </span>
+                  </div>
+                </div>
+              )}
             </div>
           </div>
 
@@ -171,7 +192,45 @@ export default function PolicyDetailsDialog({ policy, open, onClose }: PolicyDet
               </p>
             </div>
           )}
+
+          {policy.documents && policy.documents.length > 0 && (
+            <div className="space-y-2">
+              <h4 className="font-semibold text-slate-800 dark:text-slate-100">Documents</h4>
+              <div className="space-y-1">
+                {policy.documents.map((doc, idx) => (
+                  <a key={idx} href={doc.url} className="flex items-center text-emerald-600 hover:underline" target="_blank" rel="noopener noreferrer">
+                    <Download className="w-4 h-4 mr-1" /> {doc.name}
+                  </a>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {policy.reviews && policy.reviews.length > 0 && (
+            <div className="space-y-2">
+              <h4 className="font-semibold text-slate-800 dark:text-slate-100">Reviews</h4>
+              <div className="space-y-2">
+                {policy.reviews.map((review, idx) => (
+                  <div key={idx} className="p-2 rounded-lg bg-slate-50 dark:bg-slate-800/50">
+                    <div className="flex items-center mb-1">
+                      <span className="font-medium text-slate-700 dark:text-slate-300 mr-2">{review.user}</span>
+                      {Array.from({ length: 5 }).map((_, i) => (
+                        <Star
+                          key={i}
+                          className={`w-3 h-3 ${i < review.rating ? 'fill-yellow-500 text-yellow-500' : 'text-slate-400'}`}
+                        />
+                      ))}
+                    </div>
+                    <p className="text-sm text-slate-600 dark:text-slate-400">{review.comment}</p>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
         </div>
+        <DialogFooter className="mt-6">
+          <Button onClick={onClose} className="w-full sm:w-auto">Close</Button>
+        </DialogFooter>
       </DialogContent>
     </Dialog>
   );

--- a/project/lib/analytics.ts
+++ b/project/lib/analytics.ts
@@ -1,0 +1,5 @@
+export function logEvent(event: string, data?: any) {
+  if (process.env.NODE_ENV !== 'production') {
+    console.log(`[Analytics] ${event}`, data ?? '');
+  }
+}

--- a/project/public/data/policyholder/browseData.ts
+++ b/project/public/data/policyholder/browseData.ts
@@ -17,7 +17,15 @@ export const policies = [
     rating: 4.8,
     features: ['Emergency Care', 'Prescription Drugs', 'Mental Health', 'Dental'],
     popular: true,
-    description: 'Complete healthcare coverage with blockchain-verified claims processing'
+    description: 'Complete healthcare coverage with blockchain-verified claims processing',
+    documents: [
+      { name: 'Policy Terms', url: '#' },
+      { name: 'Coverage Details', url: '#' }
+    ],
+    reviews: [
+      { user: 'Alice', rating: 5, comment: 'Excellent coverage and service.' },
+      { user: 'Bob', rating: 4, comment: 'Good value for the price.' }
+    ]
   },
   {
     id: 2,
@@ -29,7 +37,11 @@ export const policies = [
     rating: 4.6,
     features: ['Trip Cancellation', 'Medical Emergency', 'Lost Luggage', '24/7 Support'],
     popular: false,
-    description: 'Worldwide travel insurance with instant claim verification'
+    description: 'Worldwide travel insurance with instant claim verification',
+    documents: [{ name: 'Policy Overview', url: '#' }],
+    reviews: [
+      { user: 'Jane', rating: 4, comment: 'Very handy for frequent travelers.' }
+    ]
   },
   {
     id: 3,
@@ -41,7 +53,8 @@ export const policies = [
     rating: 4.9,
     features: ['Weather Oracle', 'Yield Protection', 'Automated Payouts', 'Satellite Monitoring'],
     popular: true,
-    description: 'Smart contract insurance using IoT and weather data'
+    description: 'Smart contract insurance using IoT and weather data',
+    documents: [{ name: 'Policy Terms', url: '#' }]
   },
   {
     id: 4,


### PR DESCRIPTION
## Summary
- extend policy detail dialog to show rating, documents, reviews and close button
- add analytics helper
- hook policy details dialog into browse page
- create token purchase flow page
- update sample policy data with documents and reviews

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d7d6205cc8320af37c4848dfb5c90